### PR TITLE
Indicator don't bright when 'PAGE_CHANGED' notification

### DIFF
--- a/MMM-page-indicator.js
+++ b/MMM-page-indicator.js
@@ -88,7 +88,7 @@ Module.register('MMM-page-indicator', {
     if (notification === 'PAGE_CHANGED') {
       Log.log(`${this.name} recieved a notification to change to
         page ${payload}`);
-      this.curPage = payload;
+      this.curPage = mod(payload, this.config.pages);
       this.updateDom();
     } else if (notification === 'MAX_PAGES_CHANGED') {
       Log.log(`${this.name} received a notification to change the maximum


### PR DESCRIPTION
Hello,
i found that when i send a 'PAGE_CHANGED' notification, the circle don't bright, but it work with 'PAGE_INCREMENT'. so i modified this line and it work now :)