### PR TITLE
Fix for indicator overcounting as seen in issue #14

### DIFF
--- a/MMM-page-indicator.js
+++ b/MMM-page-indicator.js
@@ -23,6 +23,7 @@ Module.register('MMM-page-indicator', {
    */
   start() {
     this.curPage = 0;
+    this.mmmPagesDetected = false;
   },
 
   /**
@@ -96,11 +97,11 @@ Module.register('MMM-page-indicator', {
         this.curPage = payload - 1;
       }
       this.updateDom();
-    } else if (notification === 'PAGE_INCREMENT') {
+    } else if (notification === 'PAGE_INCREMENT' && !this.mmmPagesDetected) {
       this.curPage = mod(this.curPage + 1, this.config.pages);
       Log.log(`[${this.name}]: Incrementing page; new page is ${this.curPage}`);
       this.updateDom();
-    } else if (notification === 'PAGE_DECREMENT') {
+    } else if (notification === 'PAGE_DECREMENT' && !this.mmmPagesDetected) {
       this.curPage = mod(this.curPage - 1, this.config.pages);
       Log.log(`[${this.name}]: Decrementing page; new page is ${this.curPage}`);
       this.updateDom();
@@ -108,6 +109,9 @@ Module.register('MMM-page-indicator', {
       Log.log(`[${this.name}]: Setting page to ${payload}`);
       this.curPage = payload;
       this.updateDom();
+    } else if (notification === 'ALL_MODULES_STARTED') {
+      this.mmmPagesDetected = MM.getModules().withClass("MMM-pages").length > 0;
+      Log.log(`[${this.name}]: MMM-pages detected. Will ignore PAGE_INCREMENT and PAGE_DECREMENT as it is already handled by MMM-pages`);
     }
   },
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ this.sendNotification("MAX_PAGES_CHANGED", 4);
 
 This would now show that there are now 4 pages to display.
 
-You can also just send `PAGE_INCREMENT` or `PAGE_DECREMENT` without any payloads (or with, but it will be ignored) to have the module change the displayed page by one.
+You can also just send `PAGE_INCREMENT` or `PAGE_DECREMENT` without any payloads to have the module change the displayed page by one. If you are using [MMM-pages](https://github.com/edward-shen/MMM-pages.git) with this module, sending an integer as a payload for a `PAGE_INCREMENT` or `PAGE_DECREMENT` notification will perform as described in [the MMM-pages documentation](https://github.com/edward-shen/MMM-pages#notifications). If you are not using MMM-pages, the indicator will ignore the payload and just change the displayed page by one.
 
 ## Using the module
 


### PR DESCRIPTION
Proposed fix for issue #14. When MMM-pages is also loaded as an active MM module, it already internally handles PAGE_INCREMENT and PAGE_DECREMENT notifications by sending a NEW_PAGE notification itself. MMM-page-indicator always catches the NEW_PAGE notification before the PAGE_INCREMENT/PAGE_DECREMENT notification, so it becomes off by one.

I added a check to see if the user also has MMM-pages loaded onto their MM. If they do, then the page indicator will ignore PAGE_INCREMENT/PAGE_DECREMENT as it is already handled properly by MMM-Pages.